### PR TITLE
Manual expand in messageStore

### DIFF
--- a/src/routes/admin/message/+page.svelte
+++ b/src/routes/admin/message/+page.svelte
@@ -21,10 +21,10 @@
       })
     );
 
-    const isActive = message.id === $activeMessage.message.id;
-    if (isActive) {
-      debounce(handleActiveMessageChange, 100)(message);
-    }
+    // const isActive = message.id === $activeMessage.message.id;
+    // if (isActive) {
+    //   debounce(handleActiveMessageChange, 100)(message);
+    // }
   };
 
   const handleVisibilityChange = () => {


### PR DESCRIPTION
Subscribe individuelt til collections slik at oppdateringer registreres i expand.

@kluvin hva tenker du om denne løsningen? Hvis merget bør vi kanskje tenke på å gjøre det samme for andre stores som også bruker expand.