### PR TITLE
Oppdatere typegen action til å bruke ny github syntax

### DIFF
--- a/.github/workflows/pocketbase-typegen.yml
+++ b/.github/workflows/pocketbase-typegen.yml
@@ -59,7 +59,6 @@ jobs:
           git add --force src/lib/pocketbase/index.d.ts
           git commit -m "chore: update pocketbase types"
           git push origin "$branch"
-          echo "::set-output name=branch::$branch"
 
       - name: Create pull request
         env:

--- a/.github/workflows/pocketbase-typegen.yml
+++ b/.github/workflows/pocketbase-typegen.yml
@@ -33,9 +33,9 @@ jobs:
         # https://github.com/orgs/community/discussions/25280
         run: |
           if git diff --quiet; then
-            echo "::set-output name=commit_changes::true"
+            echo 'true' >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=commit_changes::false"
+            echo 'false' >> $GITHUB_OUTPUT
           fi
 
   pr:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/