### PR TITLE
types: save result as workflow artifact

### DIFF
--- a/.github/workflows/pocketbase-typegen.yml
+++ b/.github/workflows/pocketbase-typegen.yml
@@ -32,6 +32,12 @@ jobs:
           PB_ADMIN_EMAIL: ${{ secrets.PB_ADMIN_EMAIL }}
         run: make pb_types
 
+      - name: Upload generated types
+        uses: actions/upload-artifact@v3
+        with:
+          name: generated-types
+          path: src/lib/pocketbase/index.d.ts
+
       - name: Check for changes
         id: check_changes
         run: |
@@ -48,6 +54,15 @@ jobs:
     if: needs.typegen.outputs.commit_changes
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download generated types
+        uses: actions/download-artifact@v3
+        with:
+          name: generated-types
+          path: src/lib/pocketbase/
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
gjør at det blir sendt videre til neste job slik at den har de riktige filene, med en bonus at man også har types tilgjengelig som en artifact fra actionen.