### PR TITLE
Simplify types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -208,9 +208,9 @@ export type ExpandedActiveMessageRecord = StatusResponse & {
 };
 
 export class ActiveMessage extends Record implements RecordBase {
-  message: Message;
-  messages: Message[];
-  visible: boolean;
+  message!: Message;
+  messages!: Message[];
+  visible!: boolean;
 
   static baseValue = {
     id: "",
@@ -219,23 +219,16 @@ export class ActiveMessage extends Record implements RecordBase {
     messages: [Message.baseValue]
   } as ActiveMessage;
 
-  constructor(data: ActiveMessage) {
-    super(data);
-    this.messages = data.messages;
-    this.message = data.message;
-    this.visible = data.visible;
-  }
-
   toPb() {
     return { message: this.message.id, online: this.visible };
   }
 
   static fromPb(activeMessage: StatusResponse, messages: Message[]): ActiveMessage {
-    return new ActiveMessage({
+    return {
       id: activeMessage.id,
       message: messages.filter((m) => m.id == activeMessage.message)[0] || Message.baseValue,
       messages: messages,
       visible: activeMessage.online
-    } as ActiveMessage);
+    } as ActiveMessage;
   }
 }

--- a/src/routes/admin/message/+page.svelte
+++ b/src/routes/admin/message/+page.svelte
@@ -3,13 +3,11 @@
   import { Message, ActiveMessage } from "$lib/types";
 
   const handleActiveMessageChange = (message: Message) => {
-    activeMessage.update(
-      new ActiveMessage({
-        ...$activeMessage,
-        visible: true,
-        message
-      } as ActiveMessage)
-    );
+    activeMessage.update({
+      ...$activeMessage,
+      visible: true,
+      message
+    } as ActiveMessage);
   };
 
   const handleMessageTextChange = (event: Event, message: Message, field: "title" | "subtitle") => {
@@ -22,12 +20,10 @@
   };
 
   const handleVisibilityChange = () => {
-    activeMessage.update(
-      new ActiveMessage({
-        ...$activeMessage,
-        visible: false
-      } as ActiveMessage)
-    );
+    activeMessage.update({
+      ...$activeMessage,
+      visible: false
+    } as ActiveMessage);
   };
 </script>
 

--- a/src/routes/admin/orders/+layout.svelte
+++ b/src/routes/admin/orders/+layout.svelte
@@ -17,12 +17,10 @@
       class="btn relative m-4 flex h-24 w-1/2 flex-col items-center justify-center text-3xl lg:text-5xl
 "
       onclick={() =>
-        activeMessage.update(
-          new ActiveMessage({
-            ...$activeMessage,
-            visible: false
-          } as ActiveMessage)
-        )}>Åpne</button
+        activeMessage.update({
+          ...$activeMessage,
+          visible: false
+        } as ActiveMessage)}>Åpne</button
     >
     <a
       href="/admin/message"


### PR DESCRIPTION
@IldenH hva tenker du om å gjøre det på denne måten? Det blir funksjonelt ekvivalent med `as ActiveMessage`, som å bruke constructoren med `new ActiveMessage()`, da alt den gjorde var å sette `this.x = input.x` for alle x i input til funksjonen.