### PR TITLE
github: update pr template to use make

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@
 ## Jeg har:
 
 - [ ] Sjekket andre issues og pull requests
-- [ ] Formatert koden med `npm run format`
-- [ ] Fikset linting errors fra `npm run lint`
+- [ ] Formatert koden med `make format`
+- [ ] Fikset linting errors fra `make lint`
 - [ ] Testet koden med `make`
 - [ ] Dokumentert endringene i `/docs`
 - [ ] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)


### PR DESCRIPTION
`npm run` -> `make`

Slik som er feil under

## Jeg har:

- [x] Sjekket andre issues og pull requests
- [x] Formatert koden med `npm run format`
- [x] Fikset linting errors fra `npm run lint`
- [x] Testet koden med `make`
- [x] Dokumentert endringene i `/docs`
- [x] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)
