### PR TITLE
admin/orders: show all orders from day

### DIFF
--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -17,7 +17,8 @@
     new AdminPage("/admin/orders/kitchen", "Kjøkken"),
     new AdminPage("/display", "Visning"),
     new AdminPage("/admin/message", "Rediger skjermmelding"),
-    new AdminPage("/admin/menu", "Rediger meny")
+    new AdminPage("/admin/menu", "Rediger meny"),
+    new AdminPage("/admin/orders/stats", "Dagens bestillinger")
   ];
 </script>
 

--- a/src/routes/admin/orders/OrderList.svelte
+++ b/src/routes/admin/orders/OrderList.svelte
@@ -12,7 +12,7 @@
     detailed = true
   } = $props<{
     show: OrderStateOptions[];
-    onclick: OrderStateOptions;
+    onclick?: OrderStateOptions;
     label: string;
     detailed?: boolean;
   }>();
@@ -24,7 +24,7 @@
   }
 
   function amount() {
-    return $orders.filter((order) => order.state == show).length;
+    return $orders.filter((order) => show.includes(order.state)).length;
   }
 </script>
 
@@ -65,7 +65,7 @@
       : 'bg-base-200 cursor-pointer'}  {order.missingInformation && detailed
       ? 'bg-warning ring-warning'
       : ''} mb-6 block rounded shadow-md transition-colors"
-    onclick={() => orders.updateState(order.id, onclick)}
+    onclick={() => onclick && orders.updateState(order.id, onclick)}
     role="button"
     tabindex="0"
     onkeydown={(e) => e.key === "Enter" && orders.updateState(order.id, onclick)}

--- a/src/routes/admin/orders/stats/+page.svelte
+++ b/src/routes/admin/orders/stats/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { OrderStateOptions } from "$lib/pocketbase";
+  import OrderList from "../OrderList.svelte";
+
+  const { received, production, completed, dispatched } = OrderStateOptions;
+</script>
+
+<div class="grid h-screen grid-rows-[1fr_auto] p-4">
+  <OrderList show={[received, production, completed, dispatched]} label="Dagens bestillinger" />
+</div>


### PR DESCRIPTION
close #180 

add a simple page to show orderlist with all orders shown

## Jeg har:

- [x] Sjekket andre issues og pull requests
- [x] Formatert koden med `make format`
- [x] Fikset linting errors fra `make lint`
- [x] Testet koden med `make`
- [ ] Dokumentert endringene i `/docs`
- [x] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)
