### PR TITLE
stores: await unsubscribe

### DIFF
--- a/src/lib/stores/pbStore.ts
+++ b/src/lib/stores/pbStore.ts
@@ -25,7 +25,7 @@ export function createPbStore<Collection extends Collections, RecordClass extend
     set(initialData.map(recordClass.fromPb));
 
     if (unsubscribe) {
-      unsubscribe();
+      await unsubscribe();
     }
     unsubscribe = await pb.collection(collection).subscribe(
       "*",

--- a/src/lib/stores/statusStore.ts
+++ b/src/lib/stores/statusStore.ts
@@ -28,7 +28,7 @@ function createStatusStore() {
     set(initialData);
 
     if (unsubscribeStatus) {
-      unsubscribeStatus();
+      await unsubscribeStatus();
     }
     unsubscribeStatus = await pb.collection(Collections.Status).subscribe("*", async (event) => {
       update((state) => {
@@ -37,7 +37,7 @@ function createStatusStore() {
     });
 
     if (unsubscribeMessage) {
-      unsubscribeMessage();
+      await unsubscribeMessage();
     }
     unsubscribeMessage = await pb.collection(Collections.Message).subscribe("*", (event) => {
       update((state) => {


### PR DESCRIPTION
should close #212 

subscribe still seems to be unstable, but should work better now. this has not been thoroughly tested.

This happens sometimes:

```
Uncaught (in promise) ClientResponseError 0: Something went wrong.
    _ClientResponseError ClientResponseError.ts:13
    connectErrorHandler RealtimeService.ts:461
    connectTimeoutId RealtimeService.ts:381
Caused by: Error: EventSource connect took too long.
    connectTimeoutId RealtimeService.ts:381
ClientResponseError.ts:13:9
```

I still want to hav ethis merged, as the issue likely existed already and was not caused by this. The same issue happens in prod.

## Jeg har:

- [ ] Sjekket andre issues og pull requests
- [ ] Formatert koden med `make format`
- [ ] Fikset linting errors fra `make lint`
- [ ] Testet koden med `make`
- [ ] Dokumentert endringene i `/docs`
- [ ] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)
