### PR TITLE
menuStore: don't fetch itemCustomizations

### DIFF
--- a/src/lib/stores/menuStore.ts
+++ b/src/lib/stores/menuStore.ts
@@ -38,11 +38,3 @@ export const customizationsByKey = derived(customizationValues, ($customizationV
     return acc;
   }, {})
 );
-
-export const itemCustomizations = createGenericPbStore(
-  Collections.ItemCustomization,
-  ItemCustomization,
-  {
-    expand: "key,value"
-  }
-);

--- a/src/lib/stores/util.ts
+++ b/src/lib/stores/util.ts
@@ -1,10 +1,4 @@
-import {
-  categories,
-  items,
-  customizationKeys,
-  customizationValues,
-  itemCustomizations
-} from "$stores/menuStore";
+import { categories, items, customizationKeys, customizationValues } from "$stores/menuStore";
 
 import { raw_orders, userOrders } from "$stores/orderStore";
 import orders from "$stores/orderStore";
@@ -15,7 +9,6 @@ export function resetStores() {
   items.reset();
   customizationKeys.reset();
   customizationValues.reset();
-  itemCustomizations.reset();
   raw_orders.reset();
   userOrders.reset();
   orders.reset();


### PR DESCRIPTION
<!-- Beskriv endringen din -->

Saves around 13 kb on pageload, which gradually would increase as orders increases.

This store can be readded in the future if we want to use it for something. ItemCustomizations is already expanded by orderStore currently anyway, but maybe we will have to revisit this when we do #136.

## Jeg har:

- [ ] Sjekket andre issues og pull requests
- [ ] Formatert koden med `make format`
- [ ] Fikset linting errors fra `make lint`
- [ ] Testet koden med `make`
- [ ] Dokumentert endringene i `/docs`
- [ ] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)
