### PR TITLE
nix: remove npm

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
               plantuml
               # JS
               nodejs_20
-              nodePackages.npm
               nodePackages.typescript-language-server
               nodePackages.typescript
               emmet-ls


### PR DESCRIPTION
npm is already present in the default node.js environment. manually adding it triggered a full rebuild of node.js instead of pulling from hydra, in addition to it using the node 22 version of npm while the environment itself was on node 20.

## Jeg har:

- [ ] Sjekket andre issues og pull requests
- [ ] Formatert koden med `make format`
- [ ] Fikset linting errors fra `make lint`
- [ ] Testet koden med `make`
- [ ] Dokumentert endringene i `/docs`
- [ ] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)
