### PR TITLE
admin/orders: fix 'Åpne' button

### DIFF
--- a/src/routes/admin/orders/+layout.svelte
+++ b/src/routes/admin/orders/+layout.svelte
@@ -23,7 +23,7 @@
 "
       onclick={() =>
         status.update(
-          new Status($status.id, $status.message, $status.messages, false, $status.showMessage)
+          new Status($status.id, $status.message, $status.messages, true, $status.showMessage)
         )}>Åpne</button
     >
     <a


### PR DESCRIPTION
<!-- Beskriv endringen din -->

When I renamed status.online to status.open the boolean representation had the opposite meaning, this was changed properly most places in #206 but forgoton here.

## Jeg har:

- [ ] Sjekket andre issues og pull requests
- [ ] Formatert koden med `make format`
- [ ] Fikset linting errors fra `make lint`
- [ ] Testet koden med `make`
- [ ] Dokumentert endringene i `/docs`
- [ ] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)
