### PR TITLE
Implement github issue 259

### DIFF
--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -29,17 +29,25 @@
     new AdminPage("/admin/menu", "Rediger meny"),
     new AdminPage("/admin/stats", "Dagens bestillinger")
   ];
+
+  let isAnimating = $state(false);
+
+  function handleReset() {
+    if (window.confirm(`Er du sikker på at du vil sette alle bestillinger som utlevert?`)) {
+      isAnimating = true;
+      orders.setAll(State.dispatched);
+      setTimeout(() => {
+        isAnimating = false;
+      }, 600);
+    }
+  }
 </script>
 
 <ul>
   <li>
     <button
-      class="btn btn-error relative m-4 flex h-24 w-full flex-col items-center justify-center text-3xl lg:text-5xl"
-      onclick={() => {
-        if (window.confirm(`Er du sikker på at du vil sette alle bestillinger som utlevert?`)) {
-          orders.setAll(State.dispatched);
-        }
-      }}
+      class="btn btn-error relative m-4 flex h-24 w-full flex-col items-center justify-center text-3xl lg:text-5xl {isAnimating ? 'explosion' : ''}"
+      onclick={handleReset}
       >Nullstill bestillinger
     </button>
   </li>
@@ -53,3 +61,32 @@
     </li>
   {/each}
 </ul>
+
+<style>
+  @keyframes explosion {
+    0% {
+      transform: scale(1) rotate(0deg);
+      opacity: 1;
+    }
+    25% {
+      transform: scale(0.95) rotate(-2deg);
+    }
+    50% {
+      transform: scale(1.15) rotate(2deg);
+      box-shadow: 0 0 20px 10px rgba(239, 68, 68, 0.5);
+    }
+    75% {
+      transform: scale(1.05) rotate(-1deg);
+      box-shadow: 0 0 40px 20px rgba(239, 68, 68, 0.3);
+    }
+    100% {
+      transform: scale(1) rotate(0deg);
+      opacity: 1;
+      box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+    }
+  }
+
+  :global(.explosion) {
+    animation: explosion 0.6s ease-out;
+  }
+</style>


### PR DESCRIPTION
<!-- Beskriv endringen din -->
Implementerer en visuell animasjon for "Nullstill bestillinger"-knappen for å gi umiddelbar tilbakemelding ved klikk, som beskrevet i issue #259.

Endringen legger til en "eksplosjons"-animasjon med skalering, rotasjon og en rød glødende skygge når knappen aktiveres, noe som forbedrer brukeropplevelsen ved å visuelt bekrefte handlingen.

## Jeg har:

- [ ] Sjekket andre issues og pull requests
- [ ] Formatert koden med `make format`
- [ ] Fikset linting errors fra `make lint`
- [ ] Testet koden med `make`
- [ ] Dokumentert endringene i `/docs`
- [ ] Fulgt [retningslinjene for kontribuering](../docs/contribution.md)

---
<a href="https://cursor.com/background-agent?bcId=bc-a3092e9c-03ce-410c-90eb-ca2346cbfb66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3092e9c-03ce-410c-90eb-ca2346cbfb66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

