### PR TITLE
Fix missing cookie permissions after moving to fly

### DIFF
--- a/kaffebase/lib/kaffebase_web/endpoint.ex
+++ b/kaffebase/lib/kaffebase_web/endpoint.ex
@@ -8,7 +8,8 @@ defmodule KaffebaseWeb.Endpoint do
     store: :cookie,
     key: "_kaffebase_key",
     signing_salt: "zOysi0w2",
-    same_site: "Lax"
+    same_site: "None",
+    secure: true
   ]
 
   socket "/live", Phoenix.LiveView.Socket,


### PR DESCRIPTION
- **fix: use none samesite cookie settings**
- **fix: cookie must be none same site since moving to fly.io, we're not on the same domain, so we can't restrict sesion cookies**
